### PR TITLE
Make scope compatible with Rails 6.1 + Ruby 3.2.2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ jobs:
         include:
           - ruby: 3.2
             gemfile: gemfiles/activerecord71.gemfile
+          - ruby: 3.2
+            gemfile: gemfiles/activerecord61.gemfile
           - ruby: 3.1
             gemfile: Gemfile
           - ruby: "3.0"

--- a/lib/neighbor/model.rb
+++ b/lib/neighbor/model.rb
@@ -26,7 +26,8 @@ module Neighbor
 
         return if @neighbor_attributes.size != 1
 
-        scope :nearest_neighbors, ->(attribute_name, vector = nil, distance:) {
+        scope :nearest_neighbors, ->(attribute_name, vector = nil, options) {
+          distance = options.fetch(:distance)
           if vector.nil? && !attribute_name.nil? && attribute_name.respond_to?(:to_a)
             vector = attribute_name
             attribute_name = :neighbor_vector


### PR DESCRIPTION
It seems that scopes with keyword arguments are not supported on Rails 6.1 + Ruby 3.2.

We get the error `ArgumentError: wrong number of arguments (given 3, expected 1..2; required keyword: distance)`

Swapping the keyword argument for a hash make it to work. 🤷 